### PR TITLE
Refactor/Remove codigo duplicado nas rotas

### DIFF
--- a/servidor.go
+++ b/servidor.go
@@ -39,8 +39,7 @@ func (red *Redirecionador) ServeHTTP(
 	response http.ResponseWriter,
 	request *http.Request,
 ) {
-	caminho := strings.Split(request.URL.Path, "/")
-	id := caminho[len(caminho)-1]
+	id := extrairPathID(request)
 
 	if urlEncontrada, ok := url.Buscar(id); ok {
 		http.Redirect(response, request, urlEncontrada.Destino, http.StatusMovedPermanently)
@@ -103,8 +102,7 @@ func Encurtador(response http.ResponseWriter, request *http.Request) {
 Visualizador recupera os Stats de uma url e os retorna se for encontrada.
 */
 func Visualizador(response http.ResponseWriter, request *http.Request) {
-	caminho := strings.Split(request.URL.Path, "/")
-	id := caminho[len(caminho)-1]
+	id := extrairPathID(request)
 
 	if url, ok := url.Buscar(id); ok {
 		json, err := json.Marshal(url.Stats())
@@ -149,6 +147,11 @@ func responderComJSON(
 	})
 
 	fmt.Fprintf(response, json)
+}
+
+func extrairPathID(request *http.Request) string {
+	caminho := strings.Split(request.URL.Path, "/")
+	return caminho[len(caminho)-1]
 }
 
 func registrarEstatisticas(ids <-chan string) {


### PR DESCRIPTION
**Descrição**
No processo de melhoria e refatoração do código do servidor, foi identificado código duplicado realizando a extração do identificador da entidade no path. Além disso o comportamento na sequência era buscar a entidade com o id, se encontrar realizar algum algoritmo, se não, retornar a resposta HTTP 404 Not Found.
**O que foi feito?**
- Criada a função `extrairPathID` para extrair o id da entidade da url.
- Criada a função `rotaFindOrNotFound` que encapsula o comportameto de encontrar a entidade ou retornar HTTP 404 Not Foud. Para isso ela recebe como argumento a função que deve ser executada quando a url é encontrada.
- Refatora a função de rota Visualizador e o método ServeHTTP da struct Redirecionador para utilizar as funções criadas.